### PR TITLE
feat: When the options panel is open, treat clicking the label/select…

### DIFF
--- a/src/ReactResponsiveSelect.css
+++ b/src/ReactResponsiveSelect.css
@@ -49,7 +49,8 @@
   border-top: 1px solid #eee;
   border-radius: 0 0 2px 2px;
   top: 44px;
-  width: 100%;
+  left: 0;
+  right: 0;
   height: 0;
   visibility: hidden;
   overflow: hidden;

--- a/src/lib/eventHandlers/handleClick.ts
+++ b/src/lib/eventHandlers/handleClick.ts
@@ -61,8 +61,16 @@ export default function handleClick({
       return;
     }
 
-    // when options panel is open, treat clicking the label/select button as a 'no action'
-    if (isOptionsPanelOpen && containsClassName(event.target as HTMLElement, 'rrs__label')) {
+    /*
+      When the options panel is open, treat clicking the label/select button
+      or the background overlay on small screen as a 'no action'
+    */
+    if (
+      isOptionsPanelOpen &&
+      // button on desktop (rrs__label) or overlay on small screen (rrs)
+      (containsClassName(event.target as HTMLElement, 'rrs__label') ||
+        containsClassName(event.target as HTMLElement, 'rrs'))
+    ) {
       ReactResponsiveSelectClassRef.updateState(
         { type: actionTypes.SET_OPTIONS_PANEL_CLOSED_NO_SELECTION },
         () => ReactResponsiveSelectClassRef.focusButton(),


### PR DESCRIPTION
… button or the background overlay on small screen as a 'no action'